### PR TITLE
fixed package name in setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def read(*paths):
 
 # Prepare
 PACKAGE = 'oki'
+NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
     'six>=1.9',
 ]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ PACKAGES = find_packages(exclude=['examples', 'tests'])
 
 # Run
 setup(
-    name=PACKAGE,
+    name=NAME,
     version=VERSION,
     packages=PACKAGES,
     include_package_data=True,


### PR DESCRIPTION
We use `package_name` for python packages and `package-name` for pypi - so this PR fix problem with it.
