### PR TITLE
Feature/rename make develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - TOXENV="py${PYTHON_VERSION//./}"
 
 install:
-  - make develop
+  - make install
   - pip install coveralls
 
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Recommended way to get started is to create and activate a project virtual envir
 To install package and development dependencies into active environment:
 
 ```
-$ make develop
+$ make install
 ```
 
 ## Linting

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION := $(shell head -n 1 $(PACKAGE)/VERSION)
 
 all: list
 
-develop:
+install:
 	pip install --upgrade -e .[develop]
 
 list:


### PR DESCRIPTION
Renamed `make develop` to `make install`:
- more obvious
- it installs
- `npm install` analogue

Example - https://github.com/frictionlessdata/testsuite-py/blob/master/Makefile - where `make develop` doesn't fit good.
