### PR TITLE
Removed make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install list release test version
+.PHONY: all install list test version
 
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
@@ -12,13 +12,6 @@ install:
 
 list:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
-
-lint:
-
-release:
-	bash -c '[[ -z `git status -s` ]]'
-	git tag -a -m release $(VERSION)
-	git push --tags
 
 test:
 	pylama $(PACKAGE)


### PR DESCRIPTION
GitHub releases system covers this functionality. I suppose GitHub releases should be pointed as a way to release software in our Coding Standards.
