### PR TITLE
Move pylama to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ language:
   python
 
 python:
+  - 3.6
   - 3.5
-  - 3.4
-  - 3.3
+  # - 3.4  FIXME: Enable when https://github.com/pypa/setuptools/issues/951 is fixed
   - 2.7
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ language:
   python
 
 python:
-  - 2.7
-  - 3.3
-  - 3.4
   - 3.5
+  - 3.4
+  - 3.3
+  - 2.7
+
+matrix:
+  include:
+    - env: TOXENV=lint
 
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ as described in documentation - https://pylama.readthedocs.io/en/latest/.
 For example to sort results by error type:
 
 ```
-$ pylama --sort <path>
+$ tox -e lint -- --sort <path>
 ```
 
 For testing `tox` configured in `tox.ini` is used.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ list:
 	@grep '^\.PHONY' Makefile | cut -d' ' -f2- | tr ' ' '\n'
 
 test:
-	pylama $(PACKAGE)
 	tox
 
 version:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ INSTALL_REQUIRES = [
     'six>=1.9',
 ]
 TESTS_REQUIRE = [
-    'pylama',
     'tox',
 ]
 README = read('README.md')

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist=
   py33
   py34
   py35
+  lint
 
 [testenv]
 deps=
@@ -23,4 +24,12 @@ commands=
     --cov {[tox]package} \
     --cov-config tox.ini \
     --cov-report term-missing \
+    {posargs}
+
+[testenv:lint]
+deps=
+  pylama
+commands=
+  pylama \
+    {[tox]package} \
     {posargs}


### PR DESCRIPTION
Tox is the go-to tool for our testing process, including linting. By moving
pylama to it, the only development dependency needed is `tox`, it'll take care
of creating the separate environments. Considering that the user already have
`tox` installed, the only thing she needs to do to run our entire test
suite (which includes linting) is:

```
tox
```